### PR TITLE
Changing Top Bar text font weight to medium

### DIFF
--- a/app/src/main/java/com/lorenzovainigli/foodexpirationdates/view/composable/MyTopAppBar.kt
+++ b/app/src/main/java/com/lorenzovainigli/foodexpirationdates/view/composable/MyTopAppBar.kt
@@ -8,6 +8,7 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.lorenzovainigli.foodexpirationdates.ui.theme.FoodExpirationDatesTheme
@@ -30,7 +31,8 @@ fun MyTopAppBar(
         title = {
             Text(
                 text = title,
-                color = MaterialTheme.colorScheme.primary
+                color = MaterialTheme.colorScheme.primary,
+                fontWeight = FontWeight.Medium
             )
         },
         actions = actions,


### PR DESCRIPTION
The current view of the topbar is

<img src="https://github.com/lorenzovngl/FoodExpirationDates/assets/90559083/a9924c6e-c239-4d35-bc9d-8272b7783802" width="70%" height="70%"  />



After changing 
```kt
fontWeight = FontWeight.Medium
```

<img src="https://github.com/lorenzovngl/FoodExpirationDates/assets/90559083/4c0b82a7-64c7-415e-845c-844a2ed01031" width="70%" height="70%"  />


I noticed that the topbar font weight is normal in most of the applications.

<img src="https://github.com/lorenzovngl/FoodExpirationDates/assets/90559083/310ef6d7-3c27-4a31-aebd-90f74d454d4a" width="70%" height="70%"  />