### PR TITLE
Fix: App description text unreadable in Dark Mode

### DIFF
--- a/app/src/main/java/com/lorenzovainigli/foodexpirationdates/view/composable/AppDescription.kt
+++ b/app/src/main/java/com/lorenzovainigli/foodexpirationdates/view/composable/AppDescription.kt
@@ -22,8 +22,9 @@ const val URL_TAG = "URL"
 @Composable
 fun AppDescription(
     modifier: Modifier = Modifier,
-    textStyle: TextStyle = MaterialTheme.typography.bodyLarge
-) {
+    textStyle: TextStyle = MaterialTheme.typography.bodyLarge.copy(
+        color = MaterialTheme.colorScheme.onBackground
+    )) {
     val uriHandler = LocalUriHandler.current
     val fullText = stringResource(R.string.app_description, stringResource(id = R.string.app_name))
 


### PR DESCRIPTION
## Description

This PR fixes the issue where the **app description text** on the *About This App* screen appeared black in **Dark Mode**, making it unreadable.

### Before 
<img width="505" height="1070" alt="Screenshot 2025-10-04 215713" src="https://github.com/user-attachments/assets/d9d10e27-93b3-4b6f-b0ae-69772e4a7128" />

### After
<img width="524" height="1099" alt="image" src="https://github.com/user-attachments/assets/c3145528-6a0a-4c8e-b087-9439b5f96474" />

