### PR TITLE
Fix: Make Date Format setting clearly interactive in Settings screen

### DIFF
--- a/app/src/main/java/com/lorenzovainigli/foodexpirationdates/view/composable/screen/SettingsScreen.kt
+++ b/app/src/main/java/com/lorenzovainigli/foodexpirationdates/view/composable/screen/SettingsScreen.kt
@@ -187,14 +187,24 @@ fun SettingsScreen(
                 text += "0"
             }
             text += timePickerState.minute.toString()
-            ClickableText(
-                modifier = Modifier.testTag("Notification time"),
-                text = AnnotatedString(text),
-                style = MaterialTheme.typography.headlineMedium.copy(color = MaterialTheme.colorScheme.onSurface),
-                onClick = {
-                    isNotificationTimeBottomSheetOpen = true
-                }
-            )
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                ClickableText(
+                    modifier = Modifier.testTag("Notification time"),
+                    text = AnnotatedString(text),
+                    style = MaterialTheme.typography.headlineMedium.copy(color = MaterialTheme.colorScheme.onSurface),
+                    onClick = {
+                        isNotificationTimeBottomSheetOpen = true
+                    }
+                )
+                Icon(
+                    imageVector = Icons.Default.Edit,
+                    contentDescription = "Change notification time",
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
         }
 
         Text(stringResource(R.string.privacy),

--- a/app/src/main/java/com/lorenzovainigli/foodexpirationdates/view/composable/screen/SettingsScreen.kt
+++ b/app/src/main/java/com/lorenzovainigli/foodexpirationdates/view/composable/screen/SettingsScreen.kt
@@ -1,6 +1,7 @@
 package com.lorenzovainigli.foodexpirationdates.view.composable.screen
 
 import android.app.Activity
+import android.graphics.drawable.Icon
 import android.os.Build
 import android.util.Log
 import android.view.WindowManager
@@ -16,8 +17,12 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.foundation.text.ClickableText
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ChevronRight
+import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Surface
@@ -149,14 +154,26 @@ fun SettingsScreen(
             label = stringResource(id = R.string.date_format),
             description = stringResource(id = R.string.date_format_desc)
         ) {
-            ClickableText(
-                modifier = Modifier.testTag(stringResource(id = R.string.date_format)),
-                text = AnnotatedString(sdf.format(Calendar.getInstance().time)),
-                style = MaterialTheme.typography.headlineMedium.copy(color = MaterialTheme.colorScheme.onSurface),
-                onClick = {
-                    isDateFormatDialogOpened = true
-                }
-            )
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                ClickableText(
+                    modifier = Modifier.testTag(stringResource(id = R.string.date_format)),
+                    text = AnnotatedString(sdf.format(Calendar.getInstance().time)),
+                    style = MaterialTheme.typography.headlineMedium.copy(
+                        color = MaterialTheme.colorScheme.onSurface
+                    ),
+                    onClick = {
+                        isDateFormatDialogOpened = true
+                    }
+                )
+                Icon(
+                    imageVector = Icons.Default.Edit,
+                    contentDescription = "Change date format",
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
         }
         SettingsItem(
             label = stringResource(id = R.string.notification_time),

--- a/app/src/main/java/com/lorenzovainigli/foodexpirationdates/view/composable/screen/SettingsScreen.kt
+++ b/app/src/main/java/com/lorenzovainigli/foodexpirationdates/view/composable/screen/SettingsScreen.kt
@@ -18,7 +18,6 @@ import androidx.compose.foundation.text.BasicText
 import androidx.compose.foundation.text.ClickableText
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api


### PR DESCRIPTION
## Description
This PR updates the **Date Format setting** in the Settings screen to make it clear that the field is interactive.  
Previously, it looked like a static info field, which could confuse users.

## Screenshots

**Before**

<img width="449" height="853" alt="Screenshot 2025-10-04 224917" src="https://github.com/user-attachments/assets/50facd1f-c277-4a25-8e43-d760775ab9a4" />


**After**

<img width="449" height="853" alt="Screenshot 2025-10-04 230039" src="https://github.com/user-attachments/assets/30a2ff21-2ade-4969-b44e-2b67f51fe917" />
