### PR TITLE
Fix: Redesign Date Format Dialog for Improved Usability

### DIFF
--- a/app/src/main/java/com/lorenzovainigli/foodexpirationdates/view/composable/DateFormatDialog.kt
+++ b/app/src/main/java/com/lorenzovainigli/foodexpirationdates/view/composable/DateFormatDialog.kt
@@ -1,22 +1,33 @@
 package com.lorenzovainigli.foodexpirationdates.view.composable
 
 import android.content.Context
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.ClickableText
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import com.lorenzovainigli.foodexpirationdates.R
@@ -32,20 +43,27 @@ const val DateFormatDialog = "DateFormatDialog"
 fun DateFormatDialog(
     isDialogOpen: Boolean = true,
     onDismissRequest: () -> Unit = {},
-    onClickDate: (Context, String) -> Unit = { _, _ -> }
+    onClickDate: (Context, String) -> Unit = { _, _ -> },
+    currentFormat: String? = null
 ) {
     if (isDialogOpen) {
+        val context = LocalContext.current
+        val selectedFormat = currentFormat ?: PreferencesRepository.getUserDateFormat(context)
         Dialog(onDismissRequest = onDismissRequest) {
             Card(
                 modifier = Modifier.testTag(DateFormatDialog),
-                shape = RoundedCornerShape(10.dp),
+                shape = RoundedCornerShape(28.dp),
                 elevation = CardDefaults.cardElevation(
-                    defaultElevation = 8.dp
+                    defaultElevation = 6.dp
+                ),
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.surface
                 )
             ) {
                 Column(
                     modifier = Modifier
                         .padding(16.dp)
+                        .verticalScroll(rememberScrollState())
                 ) {
                     Text(
                         text = stringResource(id = R.string.choose_the_date_format),
@@ -54,25 +72,29 @@ fun DateFormatDialog(
                     )
                     Spacer(modifier = Modifier.padding(8.dp))
                     Text(
-                        modifier = Modifier.padding(bottom = 4.dp),
+                        modifier = Modifier.padding(bottom = 8.dp),
                         text = stringResource(id = R.string.locale_formats),
-                        color = MaterialTheme.colorScheme.onSurface
+                        style = MaterialTheme.typography.titleSmall,
+                        color = MaterialTheme.colorScheme.primary
                     )
                     PreferencesRepository.getAvailLocaleDateFormats().forEach { item ->
                         DateFormatRow(
                             item = item,
+                            isSelected = item == selectedFormat,
                             onDismissRequest = onDismissRequest,
                             onClick = onClickDate
                         )
                     }
                     Text(
-                        modifier = Modifier.padding(top = 8.dp, bottom = 4.dp),
+                        modifier = Modifier.padding(top = 16.dp, bottom = 8.dp),
                         text = stringResource(id = R.string.other_formats),
-                        color = MaterialTheme.colorScheme.onSurface
+                        style = MaterialTheme.typography.titleSmall,
+                        color = MaterialTheme.colorScheme.primary
                     )
                     PreferencesRepository.getAvailOtherDateFormats().forEach { item ->
                         DateFormatRow(
                             item = item,
+                            isSelected = item == selectedFormat,
                             onDismissRequest = onDismissRequest,
                             onClick = onClickDate
                         )
@@ -88,30 +110,65 @@ const val DateFormatRow = "DateFormatRow"
 @Composable
 fun DateFormatRow(
     item: String,
+    isSelected: Boolean = false,
     onDismissRequest: () -> Unit,
     onClick: (Context, String) -> Unit
-){
+) {
     val context = LocalContext.current
     val sdf = SimpleDateFormat(item, context.resources.configuration.locales[0])
-    ClickableText(
-        modifier = Modifier.padding(2.dp).testTag(DateFormatRow),
-        text = AnnotatedString(sdf.format(Calendar.getInstance().time)),
-        style = MaterialTheme.typography.headlineSmall.copy(color = MaterialTheme.colorScheme.onSurface),
-        onClick = {
-            onClick(context, item)
-            onDismissRequest()
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(8.dp))
+            .background(
+                if (isSelected)
+                    MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.5f)
+                else
+                    MaterialTheme.colorScheme.surface
+            )
+            .clickable {
+                onClick(context, item)
+                onDismissRequest()
+            }
+            .padding(vertical = 12.dp, horizontal = 8.dp)
+            .testTag(DateFormatRow),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        RadioButton(
+            selected = isSelected,
+            onClick = {
+                onClick(context, item)
+                onDismissRequest()
+            }
+        )
+        Spacer(modifier = Modifier.width(12.dp))
+        Text(
+            text = sdf.format(Calendar.getInstance().time),
+            style = MaterialTheme.typography.bodyLarge,
+            color = if (isSelected)
+                MaterialTheme.colorScheme.onPrimaryContainer
+            else
+                MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.weight(1f)
+        )
+        if (isSelected) {
+            Icon(
+                imageVector = Icons.Default.Check,
+                contentDescription = "Selected",
+                tint = MaterialTheme.colorScheme.primary
+            )
         }
-    )
+    }
 }
 
 @LanguagePreviews
 @Composable
-fun DateFormatDialogPreview(){
+fun DateFormatDialogPreview() {
     FoodExpirationDatesTheme {
         Surface(
             color = MaterialTheme.colorScheme.surface
         ) {
-            DateFormatDialog()
+            DateFormatDialog(currentFormat = "dd/MM/yyyy")
         }
     }
 }


### PR DESCRIPTION
## Description
This PR redesigns the **"Choose the date format"** dialog to improve usability and align with standard UI/UX conventions.

The previous implementation displayed formats as a plain text list, which was confusing for users as it didn't clearly indicate that the items were selectable or which format was currently active.

## Screenshots

**Before**

<img width="419" height="822" alt="Screenshot 2025-10-04 231447" src="https://github.com/user-attachments/assets/46a33cb9-f38a-4125-8cbc-f4535a2bee18" />

**After**

<img width="419" height="822" alt="Screenshot 2025-10-05 001329" src="https://github.com/user-attachments/assets/fdccf317-b6a3-4dec-bda3-a75d64f9edf3" />
