### PR TITLE
Fix: Edge to Edge display on BarcodeScannerScreen

### DIFF
--- a/app/src/full/java/com/lorenzovainigli/foodexpirationdates/view/composable/screen/BarCodeScannerScreen.kt
+++ b/app/src/full/java/com/lorenzovainigli/foodexpirationdates/view/composable/screen/BarCodeScannerScreen.kt
@@ -7,8 +7,12 @@ import androidx.camera.view.CameraController.COORDINATE_SYSTEM_VIEW_REFERENCED
 import androidx.camera.view.LifecycleCameraController
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.mutableStateOf
@@ -67,39 +71,47 @@ fun BarCodeScannerScreen(activity: BarcodeScannerActivity) {
             )
         }
     }
-    Column(
-        modifier = Modifier.fillMaxSize()
-    ) {
-        Box(
-            modifier = Modifier
-                .weight(1f)
-                .fillMaxWidth()
-        ) {
-            CameraPreview(
-                controller = controller,
-                modifier = Modifier.fillMaxSize()
-            )
-        }
-        if (!isOnline.value) {
-            BarcodeScannerResult(
-                activity = activity,
-                state = BarcodeScannerState.NO_CONNECTION
-            )
-        } else {
-            when (barcodeScannerState.value) {
-                BarcodeScannerState.GOT_RESULT ->
-                    BarcodeScannerResult(
-                        activity = activity,
-                        state = BarcodeScannerState.GOT_RESULT,
-                        responseOk = responseStatus.value,
-                        detectedProduct = detectedProduct.value
-                    )
 
-                else ->
-                    BarcodeScannerResult(
-                        activity = activity,
-                        state = barcodeScannerState.value
-                    )
+    Scaffold(
+        modifier = Modifier.fillMaxSize(),
+        contentWindowInsets = WindowInsets.navigationBars,
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .padding(padding)
+                .fillMaxSize()
+        ) {
+            Box(
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxWidth()
+            ) {
+                CameraPreview(
+                    controller = controller,
+                    modifier = Modifier.fillMaxSize()
+                )
+            }
+            if (!isOnline.value) {
+                BarcodeScannerResult(
+                    activity = activity,
+                    state = BarcodeScannerState.NO_CONNECTION
+                )
+            } else {
+                when (barcodeScannerState.value) {
+                    BarcodeScannerState.GOT_RESULT ->
+                        BarcodeScannerResult(
+                            activity = activity,
+                            state = BarcodeScannerState.GOT_RESULT,
+                            responseOk = responseStatus.value,
+                            detectedProduct = detectedProduct.value
+                        )
+
+                    else ->
+                        BarcodeScannerResult(
+                            activity = activity,
+                            state = barcodeScannerState.value
+                        )
+                }
             }
         }
     }


### PR DESCRIPTION
This PR fixed the `BarcodeScannerScreen` content within a `Scaffold` to properly handle the navigation bar inset.

This ensures that the UI elements, particularly the result section at the bottom, are not obscured by the system navigation bar, improving the layout on devices with gesture navigation.

This issue occurs on Android OS version 15 and above.

## Screenshots
**Before**

<img alt="Screenshot_20251005_085340" src="https://github.com/user-attachments/assets/ad6f085a-0078-4fab-81b1-6bd37a4153ba" width="230" />

<img alt="Screenshot_20251005_085244" src="https://github.com/user-attachments/assets/7a86f969-58e1-4cac-a093-39f59188f842" width="230" />


**After**

<img alt="Screenshot_20251005_084510" src="https://github.com/user-attachments/assets/0f8d638d-8ac6-4af2-97b1-55008a57b866" width="230" />


<img alt="Screenshot_20251005_084823" src="https://github.com/user-attachments/assets/108aa281-f134-4707-bc51-a103b4cee8a5"  width="230" />

