### PR TITLE
Fix: Preserve Input Data on Screen Rotation in Add Item Screen

### DIFF
--- a/app/src/main/java/com/lorenzovainigli/foodexpirationdates/view/composable/screen/InsertScreen.kt
+++ b/app/src/main/java/com/lorenzovainigli/foodexpirationdates/view/composable/screen/InsertScreen.kt
@@ -45,6 +45,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -96,7 +97,7 @@ fun InsertScreen(
         expDate = itemToEdit.expirationDate
         openingDate = itemToEdit.openingDate
     }
-    var foodName by remember {
+    var foodName by rememberSaveable {
         mutableStateOf(foodNameToEdit)
     }
     var timeSpan by remember {
@@ -175,7 +176,7 @@ fun InsertScreen(
             label = stringResource(id = R.string.expiration_date)
         )
         Spacer(modifier = Modifier.height(16.dp))
-        var quantity by remember {
+        var quantity by rememberSaveable {
             mutableIntStateOf(itemToEdit?.quantity ?: 1)
         }
         Row(


### PR DESCRIPTION
## Description
This PR addresses a critical usability bug on the **"Add item"** screen where user input in the **Food name** field and the **Quantity selector** is lost upon device rotation.

**Before**

https://github.com/user-attachments/assets/bc7849d8-19d4-45d0-8dd3-c42bc439609d


**After**

https://github.com/user-attachments/assets/ed4e82db-d45f-4a01-9455-782f2726c558


