### PR TITLE
fix: make Language setting clearly interactive with edit icon

### DIFF
--- a/app/src/main/java/com/lorenzovainigli/foodexpirationdates/view/composable/screen/SettingsScreen.kt
+++ b/app/src/main/java/com/lorenzovainigli/foodexpirationdates/view/composable/screen/SettingsScreen.kt
@@ -357,15 +357,25 @@ fun SettingsScreen(
                         .weight(1f)
                         .fillMaxHeight()
                 )
-                BasicText(
-                    modifier = Modifier.clickable {
-                        isLanguagePickerDialogOpened = true
-                    },
-                    text = Language.fromCode(PreferencesRepository.getLanguage(context)).label,
-                    style = MaterialTheme.typography.headlineSmall.copy(
-                        color = MaterialTheme.colorScheme.onSurface
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    BasicText(
+                        modifier = Modifier.clickable {
+                            isLanguagePickerDialogOpened = true
+                        },
+                        text = Language.fromCode(PreferencesRepository.getLanguage(context)).label,
+                        style = MaterialTheme.typography.headlineSmall.copy(
+                            color = MaterialTheme.colorScheme.onSurface
+                        )
                     )
-                )
+                    Icon(
+                        imageVector = Icons.Default.Edit,
+                        contentDescription = "Change language",
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
             }
         }
     }


### PR DESCRIPTION
## Description
This PR updates the **Language setting** in the Settings screen to make it clear that the field is interactive.  
Previously, it looked like a static info field, which could confuse users.

## Screenshots

**Before**

<img width="449" height="853" alt="Screenshot 2025-10-08 013033" src="https://github.com/user-attachments/assets/cb1a092d-942a-4633-abae-69fe8d20c491" />


**After**

<img width="449" height="853" alt="image" src="https://github.com/user-attachments/assets/f0e3bf6c-bd2f-490a-9b9a-bab14020ba3f" />
